### PR TITLE
symgrep: Make symbol-group handling generic

### DIFF
--- a/bash/symgrep
+++ b/bash/symgrep
@@ -11,6 +11,10 @@ init_symbol_group()
 	local symbol_group_name="$1"
 	local symbol_group_format="$2"
 
+	if [[ ! "${symbol_group_format}" =~ '%s' ]]; then
+		error_exit 'group format must contain %s'
+	fi
+
 	SYMBOL_GROUPS["$symbol_group_name"]=
 	SYMBOL_GROUP_FORMATS[$symbol_group_name]="$symbol_group_format"
 }


### PR DESCRIPTION
The script used a different variable for each of the symbol groups, and had a separate invocation line of the matching function for each group. That was not very scalable so this commit changes it:

Added a symbol-group management "API" to streamline the creation of such groups, and this is done using an associative array which holds group:symbols pair, alongside a separate symbol group format associative array whose keys match the former array. Both are created on group initialization and filled in run time.

This allowed an easier iteration on the groups, less boilerplate and less room for mistakes.